### PR TITLE
fix: convert string log levels to int for Monolog v2 compatibility

### DIFF
--- a/src/Watchers/LogWatcher.php
+++ b/src/Watchers/LogWatcher.php
@@ -10,6 +10,7 @@ use Illuminate\Log\LogManager;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\API\Logs\LogRecord;
 use OpenTelemetry\API\Logs\Map\Psr3;
+use Monolog\Logger as MonologLogger;
 
 class LogWatcher extends Watcher
 {
@@ -37,8 +38,11 @@ class LogWatcher extends Watcher
         $underlyingLogger = $this->logger->getLogger();
 
         /** @phan-suppress-next-line PhanUndeclaredMethod */
-        if (method_exists($underlyingLogger, 'isHandling') && !$underlyingLogger->isHandling($log->level)) {
-            return;
+        if (method_exists($underlyingLogger, 'isHandling')) {
+            $level = is_string($log->level) ? MonologLogger::toMonologLevel($log->level) : $log->level;
+            if (!$underlyingLogger->isHandling($level)) {
+                return;
+            }
         }
 
         $attributes = [


### PR DESCRIPTION
## Problem
The LogWatcher class is currently passing string log levels to Monolog's `isHandling()` method, which expects an integer in older versions (Monolog v2.x, used by Laravel 9). This causes a TypeError:
```bash
TypeError: Monolog\Logger::isHandling(): Argument #1 ($level) must be of type int, string given
```
## Cause
Laravel 9 uses Monolog v2.x where `isHandling()` only accepts integers, while the LogWatcher passes string levels directly from Laravel's MessageLogged event.

## Solution
Use Monolog's built-in `toMonologLevel()` method to safely convert string levels to their integer equivalents. The change also maintains backwards compatibility by checking if the level is already an integer.