### PR TITLE
[opentelemetry-auto-laravel] Redis params could be array

### DIFF
--- a/src/Watchers/RedisCommand/Serializer.php
+++ b/src/Watchers/RedisCommand/Serializer.php
@@ -64,6 +64,11 @@ class Serializer
         // Serialize the allowed number of arguments
         $paramsToSerialize = ($paramsToSerializeNum >= 0) ? array_slice($params, 0, $paramsToSerializeNum) : $params;
 
+        // Map each parameter to a string representation
+        $paramsToSerialize = array_map(function ($param) {
+            return is_array($param) ? json_encode($param) : (string)$param;
+        }, $paramsToSerialize);
+        
         // If there are more arguments than serialized, add a placeholder
         if (count($params) > count($paramsToSerialize)) {
             $paramsToSerialize[] = '[' . (count($params) - $paramsToSerializeNum) . ' other arguments]';


### PR DESCRIPTION
**Describe your environment**

PHP 8.2
Laravel 11.14
opentelemetry-auto-laravel 1.0.0

**Steps to reproduce**

Make a custom command `app/Console/Commands/Test.php`, in handle() method dispatches a job. When execute my command it shows `Array to string conversion`.

My `.env` file
```
CACHE_STORE=redis
QUEUE_CONNECTION=redis
```

**What is the expected behavior?**
It should't show this error.

**What is the actual behavior?**
![image](https://github.com/user-attachments/assets/5ae648b8-80ff-4b1e-ba60-ad1568563b9c)

**Additional context**
None.
