### PR TITLE
feat: add laravel-mongodb support

### DIFF
--- a/src/Hooks/Illuminate/Database/Eloquent/Model.php
+++ b/src/Hooks/Illuminate/Database/Eloquent/Model.php
@@ -159,6 +159,13 @@ class Model implements LaravelHook
             'getModels',
             pre: function ($builder, array $params, string $class, string $function, ?string $filename, ?int $lineno) {
                 $model = $builder->getModel();
+
+                if ($model instanceof \MongoDB\Laravel\Eloquent\Model) {
+                    $statement = json_encode($builder->getQuery()->toMql());
+                } else {
+                    $statement = $builder->getQuery()->toSql();
+                }
+
                 $builder = $this->instrumentation
                     ->tracer()
                     ->spanBuilder($model::class . '::get')
@@ -169,7 +176,7 @@ class Model implements LaravelHook
                     ->setAttribute('laravel.eloquent.model', $model::class)
                     ->setAttribute('laravel.eloquent.table', $model->getTable())
                     ->setAttribute('laravel.eloquent.operation', 'get')
-                    ->setAttribute('db.statement', $builder->getQuery()->toSql());
+                    ->setAttribute('db.statement', $statement);
 
                 $parent = Context::getCurrent();
                 $span = $builder->startSpan();


### PR DESCRIPTION
## Description

This PR adds support for the [laravel-mongodb](https://github.com/mongodb/laravel-mongodb) library by implementing conditional logic to handle MongoDB-specific query building methods.

## Problem 

Currently, the auto instrumentation triggers the following error when using Laravel MongoDB models:

```
PHP Warning:  Illuminate\\Database\\Eloquent\\Builder::getModels(): OpenTelemetry: pre hook threw exception, class=Illuminate\\Database\\Eloquent\\Builder function=getModels message=This method is not supported by MongoDB. Try &quot;toMql()&quot; instead. in Unknown on line 0
```

This occurs because the instrumentation attempts to call `toSql()` on MongoDB query builders, which is not supported. MongoDB query builders use `toMql()` instead to generate MongoDB Query Language statements.
